### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 on: [push, pull_request]
 name: Test
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/boggydigital/kevlar/security/code-scanning/1](https://github.com/boggydigital/kevlar/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Since the workflow only needs to read the repository contents (e.g., to check out code), we will set `contents: read`. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to complete the tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
